### PR TITLE
Fixed problem with virsh response evaluated in ExecStop depending on locale.

### DIFF
--- a/virtctl@.service
+++ b/virtctl@.service
@@ -45,7 +45,7 @@ ExecStartPost=-/usr/bin/timeout -k 10 50 bash -c '[ -f ${FUNCTIONS} ] && source 
 # while the domain is still running. Allowed to fail.
 ExecStop=-/usr/bin/timeout -k 10 50 bash -c '[ -f ${FUNCTIONS} ] && source ${FUNCTIONS} ExecStopPre; [ "$(type -t virtctl_stoppre)" = "function" ] && virtctl_stoppre || :'
 # Shutdown the domain gracefully by sending ACPI shutdown event.
-ExecStop=/usr/bin/bash -c 'COUNT=0; while [ $COUNT -le 60 ]; do STATE=$(virsh domstate %i 2>&1); if [ "$STATE" = "running" ]; then [ $(($COUNT % 15)) -eq 0 ] && virsh shutdown %i; ((COUNT++)); elif [ "$STATE" = "shut off" ] || [ "${STATE::27}" = "error: failed to get domain" ]; then exit 0; fi; sleep 1; done; exit 1'
+ExecStop=/usr/bin/bash -c 'export LANG=C; COUNT=0; while [ $COUNT -le 60 ]; do STATE=$(virsh domstate %i 2>&1); if [ "$STATE" = "running" ]; then [ $(($COUNT % 15)) -eq 0 ] && virsh shutdown %i; ((COUNT++)); elif [ "$STATE" = "shut off" ] || [ "${STATE::27}" = "error: failed to get domain" ]; then exit 0; fi; sleep 1; done; exit 1'
 # Provide a (optional) post-stop functionality per domain. Not allowed to fail
 # because it doesn't make a difference at this point.
 ExecStopPost=/usr/bin/bash -c '[ -f ${FUNCTIONS} ] && source ${FUNCTIONS} ExecStopPost || :'


### PR DESCRIPTION
Hey  @dehesselle, thanks for this useful piece of systemd Fu!

I ran into a minor problem settings things up. virsh output depends on the locale used:

```
$LANG=de_DE.UTF-8 virsh domstate testdom
laufend

$LANG=C virsh domstate testdom
running
```

Evaluating it in the ExecStop call then leads to an error.